### PR TITLE
Better recognition control

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,25 @@ Transcription of all speech that has been spoken into the microphone. Is equival
 
 Sets the transcription to an empty string.
 
+### startListening [function]
+
+Causes the Web Speech API to start listening to speech from the microphone.
+
+### stopListening [function]
+
+Causes the Web Speech API to stop listening to speech from the microphone, but will finish processing any remaining speech.
+
+### abortListening [function]
+
+Causes the Web Speech API to stop listening to speech from the microphone, and also stop processing the current speech. Initially, the Web Speech API is turned on, so you may want to call this in `componentWillMount` if you don't want speech to be collected when your component is first mounted.
+
 ### browserSupportsSpeechRecognition [bool]
 
 If false, the browser does not support the Speech Recognition API.
+
+### listening [bool]
+
+If true, the Web Speech API is listening to speech from the microphone.
 
 ### interimTranscript [string]
 

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -1,23 +1,23 @@
 import React, { Component } from 'react'
 import { debounce, autobind } from 'core-decorators'
 
-const BrowserSpeechRecognition =
-  window.SpeechRecognition ||
-  window.webkitSpeechRecognition ||
-  window.mozSpeechRecognition ||
-  window.msSpeechRecognition ||
-  window.oSpeechRecognition
-const recognition = BrowserSpeechRecognition
-  ? new BrowserSpeechRecognition()
-  : null
-const browserSupportsSpeechRecognition = recognition !== null
-recognition.start()
-let listening = true
-let isManuallyDisconnected = false
-let interimTranscript = ''
-let finalTranscript = ''
-
 export default function SpeechRecognition(WrappedComponent) {
+  const BrowserSpeechRecognition =
+    window.SpeechRecognition ||
+    window.webkitSpeechRecognition ||
+    window.mozSpeechRecognition ||
+    window.msSpeechRecognition ||
+    window.oSpeechRecognition
+  const recognition = BrowserSpeechRecognition
+    ? new BrowserSpeechRecognition()
+    : null
+  const browserSupportsSpeechRecognition = recognition !== null
+  recognition.start()
+  let listening = true
+  let isManuallyDisconnected = false
+  let interimTranscript = ''
+  let finalTranscript = ''
+
   return class SpeechRecognitionContainer extends Component {
     constructor(props) {
       super(props)

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -1,6 +1,16 @@
 import React, { Component } from 'react'
 import { debounce, autobind } from 'core-decorators'
 
+const BrowserSpeechRecognition =
+  window.SpeechRecognition ||
+  window.webkitSpeechRecognition ||
+  window.mozSpeechRecognition ||
+  window.msSpeechRecognition ||
+  window.oSpeechRecognition
+const recognition = BrowserSpeechRecognition
+  ? new BrowserSpeechRecognition()
+  : null
+
 export default function SpeechRecognition(WrappedComponent) {
   return class SpeechRecognitionContainer extends Component {
     constructor(props) {
@@ -15,14 +25,7 @@ export default function SpeechRecognition(WrappedComponent) {
     }
 
     componentWillMount() {
-      const root = typeof window !== 'undefined' ? window : this
-      const BrowserSpeechRecognition = root.SpeechRecognition ||
-                                       root.webkitSpeechRecognition ||
-                                       root.mozSpeechRecognition ||
-                                       root.msSpeechRecognition ||
-                                       root.oSpeechRecognition
-      if (BrowserSpeechRecognition) {
-        const recognition = new BrowserSpeechRecognition()
+      if (recognition) {
         recognition.continuous = true
         recognition.interimResults = true
         recognition.onresult = this.updateTranscript.bind(this)

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -10,6 +10,7 @@ const BrowserSpeechRecognition =
 const recognition = BrowserSpeechRecognition
   ? new BrowserSpeechRecognition()
   : null
+const browserSupportsSpeechRecognition = recognition !== null
 recognition.start()
 let listening = true
 let isManuallyDisconnected = false
@@ -24,8 +25,6 @@ export default function SpeechRecognition(WrappedComponent) {
       this.state = {
         interimTranscript,
         finalTranscript,
-        recognition: null,
-        browserSupportsSpeechRecognition: true,
         listening: false
       }
     }
@@ -36,23 +35,21 @@ export default function SpeechRecognition(WrappedComponent) {
         recognition.interimResults = true
         recognition.onresult = this.updateTranscript.bind(this)
         recognition.onend = this.onRecognitionDisconnect.bind(this)
-        this.setState({ recognition, listening })
-      } else {
-        this.setState({ browserSupportsSpeechRecognition: false })
+        this.setState({ listening })
       }
     }
 
     @autobind
     manualDisconnect(disconnectType) {
-      if (this.state.recognition) {
+      if (recognition) {
         isManuallyDisconnected = true
         switch (disconnectType) {
           case 'ABORT':
-            this.state.recognition.abort()
+            recognition.abort()
             break
           case 'STOP':
           default:
-            this.state.recognition.stop()
+            recognition.stop()
         }
       }
     }
@@ -98,14 +95,14 @@ export default function SpeechRecognition(WrappedComponent) {
     resetTranscript() {
       interimTranscript = ''
       finalTranscript = ''
-      this.state.recognition.abort()
+      recognition.abort()
       this.setState({ interimTranscript, finalTranscript })
     }
 
     @autobind
     startListening() {
-      if (this.state.recognition && !listening) {
-        this.state.recognition.start()
+      if (recognition && !listening) {
+        recognition.start()
         listening = true
         this.setState({ listening })
       }
@@ -138,6 +135,8 @@ export default function SpeechRecognition(WrappedComponent) {
           abortListening={this.abortListening}
           stopListening={this.stopListening}
           transcript={transcript}
+          recognition={recognition}
+          browserSupportsSpeechRecognition={browserSupportsSpeechRecognition}
           {...this.state}
           {...this.props} />
       )

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -87,6 +87,30 @@ export default function SpeechRecognition(WrappedComponent) {
       }
     }
 
+    @autobind
+    startListening() {
+      if (this.state.recognition) {
+        this.state.recognition.start()
+        this.setState({ listening: true })
+      }
+    }
+
+    @autobind
+    abortListening() {
+      this.setState({ listening: false })
+      if (this.state.recognition) {
+        this.state.recognition.abort()
+      }
+    }
+
+    @autobind
+    stopListening() {
+      this.setState({ listening: false })
+      if (this.state.recognition) {
+        this.state.recognition.stop()
+      }
+    }
+
     render() {
       const { finalTranscript, interimTranscript } = this.state
       const transcript = this.concatTranscripts(
@@ -97,6 +121,9 @@ export default function SpeechRecognition(WrappedComponent) {
       return (
         <WrappedComponent
           resetTranscript={this.resetTranscript}
+          startListening={this.startListening}
+          abortListening={this.abortListening}
+          stopListening={this.stopListening}
           transcript={transcript}
           {...this.state}
           {...this.props} />

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -57,10 +57,10 @@ export default function SpeechRecognition(WrappedComponent) {
 
     @debounce(1000)
     onRecognitionDisconnect() {
+      listening = false
       if (!isManuallyDisconnected) {
         this.startListening()
       } else {
-        listening = false
         this.setState({ listening })
       }
       isManuallyDisconnected = false
@@ -105,7 +105,7 @@ export default function SpeechRecognition(WrappedComponent) {
 
     @autobind
     startListening() {
-      if (this.state.recognition) {
+      if (this.state.recognition && !listening) {
         this.state.recognition.start()
         listening = true
         this.setState({ listening })

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { debounce, autobind } from 'core-decorators'
+import { autobind } from 'core-decorators'
 
 const BrowserSpeechRecognition =
   window.SpeechRecognition ||
@@ -29,7 +29,6 @@ export default function SpeechRecognition(WrappedComponent) {
         recognition.continuous = true
         recognition.interimResults = true
         recognition.onresult = this.updateTranscript.bind(this)
-        recognition.onend = this.restartRecognition.bind(this)
         recognition.start()
         this.setState({ recognition })
       } else {
@@ -40,13 +39,6 @@ export default function SpeechRecognition(WrappedComponent) {
     componentWillUnmount() {
       if (this.state.recognition) {
         this.state.recognition.abort()
-      }
-    }
-
-    @debounce(1000)
-    restartRecognition() {
-      if (this.state.recognition) {
-        this.state.recognition.start()
       }
     }
 

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -62,10 +62,10 @@ export default function SpeechRecognition(WrappedComponent) {
     @debounce(1000)
     onRecognitionDisconnect() {
       listening = false
-      if (!pauseAfterDisconnect) {
-        this.startListening()
-      } else {
+      if (pauseAfterDisconnect) {
         this.setState({ listening })
+      } else {
+        this.startListening()
       }
       pauseAfterDisconnect = false
     }

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -66,11 +66,6 @@ export default function SpeechRecognition(WrappedComponent) {
     }
 
     updateTranscript(event) {
-      this.setNewTranscript(event)
-      this.setState({ finalTranscript, interimTranscript })
-    }
-
-    setNewTranscript(event) {
       interimTranscript = ''
       for (let i = event.resultIndex; i < event.results.length; ++i) {
         if (event.results[i].isFinal) {
@@ -85,6 +80,7 @@ export default function SpeechRecognition(WrappedComponent) {
           )
         }
       }
+      this.setState({ finalTranscript, interimTranscript })
     }
 
     concatTranscripts(...transcriptParts) {

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -20,7 +20,8 @@ export default function SpeechRecognition(WrappedComponent) {
         interimTranscript: '',
         finalTranscript: '',
         recognition: null,
-        browserSupportsSpeechRecognition: true
+        browserSupportsSpeechRecognition: true,
+        listening: false
       }
     }
 
@@ -29,8 +30,9 @@ export default function SpeechRecognition(WrappedComponent) {
         recognition.continuous = true
         recognition.interimResults = true
         recognition.onresult = this.updateTranscript.bind(this)
+        recognition.onend = this.onRecognitionDisconnect.bind(this)
         recognition.start()
-        this.setState({ recognition })
+        this.setState({ recognition, listening: true })
       } else {
         this.setState({ browserSupportsSpeechRecognition: false })
       }
@@ -40,6 +42,10 @@ export default function SpeechRecognition(WrappedComponent) {
       if (this.state.recognition) {
         this.state.recognition.abort()
       }
+    }
+
+    onRecognitionDisconnect() {
+      this.setState({ listening: false })
     }
 
     updateTranscript(event) {

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -51,7 +51,9 @@ export default function SpeechRecognition(WrappedComponent) {
     }
 
     updateTranscript(event) {
-      const { finalTranscript, interimTranscript } = this.getNewTranscript(event)
+      const { finalTranscript, interimTranscript } = this.getNewTranscript(
+        event
+      )
 
       this.setState({ finalTranscript, interimTranscript })
     }
@@ -61,9 +63,15 @@ export default function SpeechRecognition(WrappedComponent) {
       let interimTranscript = ''
       for (let i = event.resultIndex; i < event.results.length; ++i) {
         if (event.results[i].isFinal) {
-          finalTranscript = this.concatTranscripts(finalTranscript, event.results[i][0].transcript)
+          finalTranscript = this.concatTranscripts(
+            finalTranscript,
+            event.results[i][0].transcript
+          )
         } else {
-          interimTranscript = this.concatTranscripts(interimTranscript, event.results[i][0].transcript)
+          interimTranscript = this.concatTranscripts(
+            interimTranscript,
+            event.results[i][0].transcript
+          )
         }
       }
       return { finalTranscript, interimTranscript }
@@ -83,7 +91,10 @@ export default function SpeechRecognition(WrappedComponent) {
 
     render() {
       const { finalTranscript, interimTranscript } = this.state
-      const transcript = this.concatTranscripts(finalTranscript, interimTranscript)
+      const transcript = this.concatTranscripts(
+        finalTranscript,
+        interimTranscript
+      )
 
       return (
         <WrappedComponent


### PR DESCRIPTION
The goal of this PR is to give the user more control over the Web Speech API. Previously, the recognition object was not aborting speech recognition detection correctly, and was failing on re-renders. The use of a singleton recognition object and improved controls should alleviate this issue.

* `listening` bool prop: if true, the Web Speech API is listening to speech from the microphone.
* `startListening` func prop: causes the Web Speech API to start listening to speech from the microphone.
* `stopListening` func prop: causes the Web Speech API to stop listening to speech from the microphone, but will finish processing any remaining speech.
* `abortListening` func prop: causes the Web Speech API to stop listening to speech from the microphone, and also stop processing the current speech. Initially, the Web Speech API is turned on, so you may want to call this in `componentWillMount` if you don't want speech to be collected when your component is first mounted.