### PR TITLE
Configurable default state

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,26 @@ If you are writing ES7 code, you can add the `@SpeechRecognition` decorator
 to your component's class. To use the decorator syntax, add the
 [decorator plugin](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy) to Babel.
 
+## Global options
+
+You can configure the default initial state of the Speech Recognition API. To change these defaults, you need to pass an options object into the wrapper like so:
+
+```
+const options = {
+  autoStart: false
+}
+
+export default SpeechRecognition(options)(YourComponent)
+```
+
+or in ES7:
+
+`@SpeechRecognition(options)`
+
+### autoStart [bool]
+
+By default, the Speech Recognition API is listening to speech from the microphone. To have the API turned off by default, set this to `false`.
+
 ## Props added to your component
 
 ### transcript [string]

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -45,6 +45,11 @@ export default function SpeechRecognition(options) {
         }
       }
 
+      componentWillUnmount() {
+        recognition.onresult = null
+        recognition.onend = null
+      }
+
       @autobind
       disconnect(disconnectType) {
         if (recognition) {

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { debounce, autobind } from 'core-decorators'
 
 export default function SpeechRecognition(options) {
-  return function SpeechRecognitionInner(WrappedComponent) {
+  const SpeechRecognitionInner = function (WrappedComponent) {
     const BrowserSpeechRecognition =
       window.SpeechRecognition ||
       window.webkitSpeechRecognition ||
@@ -149,5 +149,11 @@ export default function SpeechRecognition(options) {
         )
       }
     }
+  }
+
+  if (typeof options === 'function') {
+    return SpeechRecognitionInner(options)
+  } else {
+    return SpeechRecognitionInner
   }
 }

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -14,7 +14,7 @@ export default function SpeechRecognition(options) {
       : null
     const browserSupportsSpeechRecognition = recognition !== null
     let listening
-    if (options.autoStart === false) {
+    if (options && options.autoStart === false) {
       listening = false
     } else {
       recognition.start()

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -108,7 +108,11 @@ export default function SpeechRecognition(options) {
       @autobind
       startListening() {
         if (recognition && !listening) {
-          recognition.start()
+          try {
+            recognition.start()
+          } catch (DOMException) {
+            // Tried to start recognition after it has already started - safe to swallow this error
+          }
           listening = true
           this.setState({ listening })
         }

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { debounce, autobind } from 'core-decorators'
+import { autobind } from 'core-decorators'
 
 export default function SpeechRecognition(options) {
   const SpeechRecognitionInner = function (WrappedComponent) {
@@ -45,11 +45,6 @@ export default function SpeechRecognition(options) {
         }
       }
 
-      componentWillUnmount() {
-        recognition.onresult = null
-        recognition.onend = null
-      }
-
       @autobind
       disconnect(disconnectType) {
         if (recognition) {
@@ -70,7 +65,6 @@ export default function SpeechRecognition(options) {
         }
       }
 
-      @debounce(1000)
       onRecognitionDisconnect() {
         listening = false
         if (pauseAfterDisconnect) {

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -1,146 +1,153 @@
 import React, { Component } from 'react'
 import { debounce, autobind } from 'core-decorators'
 
-export default function SpeechRecognition(WrappedComponent) {
-  const BrowserSpeechRecognition =
-    window.SpeechRecognition ||
-    window.webkitSpeechRecognition ||
-    window.mozSpeechRecognition ||
-    window.msSpeechRecognition ||
-    window.oSpeechRecognition
-  const recognition = BrowserSpeechRecognition
-    ? new BrowserSpeechRecognition()
-    : null
-  const browserSupportsSpeechRecognition = recognition !== null
-  recognition.start()
-  let listening = true
-  let pauseAfterDisconnect = false
-  let interimTranscript = ''
-  let finalTranscript = ''
-
-  return class SpeechRecognitionContainer extends Component {
-    constructor(props) {
-      super(props)
-
-      this.state = {
-        interimTranscript,
-        finalTranscript,
-        listening: false
-      }
+export default function SpeechRecognition(options) {
+  return function SpeechRecognitionInner(WrappedComponent) {
+    const BrowserSpeechRecognition =
+      window.SpeechRecognition ||
+      window.webkitSpeechRecognition ||
+      window.mozSpeechRecognition ||
+      window.msSpeechRecognition ||
+      window.oSpeechRecognition
+    const recognition = BrowserSpeechRecognition
+      ? new BrowserSpeechRecognition()
+      : null
+    const browserSupportsSpeechRecognition = recognition !== null
+    let listening
+    if (options.autoStart === false) {
+      listening = false
+    } else {
+      recognition.start()
+      listening = true
     }
+    let pauseAfterDisconnect = false
+    let interimTranscript = ''
+    let finalTranscript = ''
 
-    componentWillMount() {
-      if (recognition) {
-        recognition.continuous = true
-        recognition.interimResults = true
-        recognition.onresult = this.updateTranscript.bind(this)
-        recognition.onend = this.onRecognitionDisconnect.bind(this)
-        this.setState({ listening })
-      }
-    }
+    return class SpeechRecognitionContainer extends Component {
+      constructor(props) {
+        super(props)
 
-    @autobind
-    disconnect(disconnectType) {
-      if (recognition) {
-        switch (disconnectType) {
-          case 'ABORT':
-            pauseAfterDisconnect = true
-            recognition.abort()
-            break
-          case 'RESET':
-            pauseAfterDisconnect = false
-            recognition.abort()
-            break
-          case 'STOP':
-          default:
-            pauseAfterDisconnect = true
-            recognition.stop()
+        this.state = {
+          interimTranscript,
+          finalTranscript,
+          listening: false
         }
       }
-    }
 
-    @debounce(1000)
-    onRecognitionDisconnect() {
-      listening = false
-      if (pauseAfterDisconnect) {
-        this.setState({ listening })
-      } else {
-        this.startListening()
+      componentWillMount() {
+        if (recognition) {
+          recognition.continuous = true
+          recognition.interimResults = true
+          recognition.onresult = this.updateTranscript.bind(this)
+          recognition.onend = this.onRecognitionDisconnect.bind(this)
+          this.setState({ listening })
+        }
       }
-      pauseAfterDisconnect = false
-    }
 
-    updateTranscript(event) {
-      interimTranscript = ''
-      for (let i = event.resultIndex; i < event.results.length; ++i) {
-        if (event.results[i].isFinal) {
-          finalTranscript = this.concatTranscripts(
-            finalTranscript,
-            event.results[i][0].transcript
-          )
+      @autobind
+      disconnect(disconnectType) {
+        if (recognition) {
+          switch (disconnectType) {
+            case 'ABORT':
+              pauseAfterDisconnect = true
+              recognition.abort()
+              break
+            case 'RESET':
+              pauseAfterDisconnect = false
+              recognition.abort()
+              break
+            case 'STOP':
+            default:
+              pauseAfterDisconnect = true
+              recognition.stop()
+          }
+        }
+      }
+
+      @debounce(1000)
+      onRecognitionDisconnect() {
+        listening = false
+        if (pauseAfterDisconnect) {
+          this.setState({ listening })
         } else {
-          interimTranscript = this.concatTranscripts(
-            interimTranscript,
-            event.results[i][0].transcript
-          )
+          this.startListening()
+        }
+        pauseAfterDisconnect = false
+      }
+
+      updateTranscript(event) {
+        interimTranscript = ''
+        for (let i = event.resultIndex; i < event.results.length; ++i) {
+          if (event.results[i].isFinal) {
+            finalTranscript = this.concatTranscripts(
+              finalTranscript,
+              event.results[i][0].transcript
+            )
+          } else {
+            interimTranscript = this.concatTranscripts(
+              interimTranscript,
+              event.results[i][0].transcript
+            )
+          }
+        }
+        this.setState({ finalTranscript, interimTranscript })
+      }
+
+      concatTranscripts(...transcriptParts) {
+        return transcriptParts.map(t => t.trim()).join(' ').trim()
+      }
+
+      @autobind
+      resetTranscript() {
+        interimTranscript = ''
+        finalTranscript = ''
+        this.disconnect('RESET')
+        this.setState({ interimTranscript, finalTranscript })
+      }
+
+      @autobind
+      startListening() {
+        if (recognition && !listening) {
+          recognition.start()
+          listening = true
+          this.setState({ listening })
         }
       }
-      this.setState({ finalTranscript, interimTranscript })
-    }
 
-    concatTranscripts(...transcriptParts) {
-      return transcriptParts.map(t => t.trim()).join(' ').trim()
-    }
-
-    @autobind
-    resetTranscript() {
-      interimTranscript = ''
-      finalTranscript = ''
-      this.disconnect('RESET')
-      this.setState({ interimTranscript, finalTranscript })
-    }
-
-    @autobind
-    startListening() {
-      if (recognition && !listening) {
-        recognition.start()
-        listening = true
+      @autobind
+      abortListening() {
+        listening = false
         this.setState({ listening })
+        this.disconnect('ABORT')
       }
-    }
 
-    @autobind
-    abortListening() {
-      listening = false
-      this.setState({ listening })
-      this.disconnect('ABORT')
-    }
+      @autobind
+      stopListening() {
+        listening = false
+        this.setState({ listening })
+        this.disconnect('STOP')
+      }
 
-    @autobind
-    stopListening() {
-      listening = false
-      this.setState({ listening })
-      this.disconnect('STOP')
-    }
+      render() {
+        const transcript = this.concatTranscripts(
+          finalTranscript,
+          interimTranscript
+        )
 
-    render() {
-      const transcript = this.concatTranscripts(
-        finalTranscript,
-        interimTranscript
-      )
-
-      return (
-        <WrappedComponent
-          resetTranscript={this.resetTranscript}
-          startListening={this.startListening}
-          abortListening={this.abortListening}
-          stopListening={this.stopListening}
-          transcript={transcript}
-          recognition={recognition}
-          browserSupportsSpeechRecognition={browserSupportsSpeechRecognition}
-          {...this.state}
-          {...this.props} />
-      )
+        return (
+          <WrappedComponent
+            resetTranscript={this.resetTranscript}
+            startListening={this.startListening}
+            abortListening={this.abortListening}
+            stopListening={this.stopListening}
+            transcript={transcript}
+            recognition={recognition}
+            browserSupportsSpeechRecognition={browserSupportsSpeechRecognition}
+            {...this.state}
+            {...this.props} />
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
## Global options

You can configure the default initial state of the Speech Recognition API. To change these defaults, you need to pass an options object into the wrapper like so:

```
const options = {
  autoStart: false
}

export default SpeechRecognition(options)(YourComponent)
```

or in ES7:

`@SpeechRecognition(options)`

### autoStart [bool]

By default, the Speech Recognition API is listening to speech from the microphone. To have the API turned off by default, set this to `false`.