### PR TITLE
Enable server side rendering

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,3 @@
 {
-  "presets": ["es2015", "stage-0", "react"],
-  "plugins": [
-    "babel-plugin-transform-decorators-legacy"
-  ]
+  "presets": ["es2015", "stage-0", "react"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-speech-recognition",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A React component that converts speech from the microphone to text.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,14 +15,12 @@
   "author": "James Brill <james.brill@foundersfactory.co>",
   "license": "MIT",
   "dependencies": {
-    "core-decorators": "^0.14.0",
     "react": "^15.4.1"
   },
   "devDependencies": {
     "babel-core": "^6.21.0",
     "babel-eslint": "^7.1.1",
     "babel-loader": "^6.2.9",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -3,17 +3,21 @@ import React, { Component } from 'react'
 export default function SpeechRecognition(options) {
   const SpeechRecognitionInner = function (WrappedComponent) {
     const BrowserSpeechRecognition =
-      window.SpeechRecognition ||
-      window.webkitSpeechRecognition ||
-      window.mozSpeechRecognition ||
-      window.msSpeechRecognition ||
-      window.oSpeechRecognition
+      typeof window !== 'undefined' &&
+      (window.SpeechRecognition ||
+        window.webkitSpeechRecognition ||
+        window.mozSpeechRecognition ||
+        window.msSpeechRecognition ||
+        window.oSpeechRecognition)
     const recognition = BrowserSpeechRecognition
       ? new BrowserSpeechRecognition()
       : null
     const browserSupportsSpeechRecognition = recognition !== null
     let listening
-    if (options && options.autoStart === false) {
+    if (
+      !browserSupportsSpeechRecognition ||
+      (options && options.autoStart === false)
+    ) {
       listening = false
     } else {
       recognition.start()

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { autobind } from 'core-decorators'
 
 export default function SpeechRecognition(options) {
   const SpeechRecognitionInner = function (WrappedComponent) {
@@ -45,8 +44,7 @@ export default function SpeechRecognition(options) {
         }
       }
 
-      @autobind
-      disconnect(disconnectType) {
+      disconnect = disconnectType => {
         if (recognition) {
           switch (disconnectType) {
             case 'ABORT':
@@ -97,16 +95,14 @@ export default function SpeechRecognition(options) {
         return transcriptParts.map(t => t.trim()).join(' ').trim()
       }
 
-      @autobind
-      resetTranscript() {
+      resetTranscript = () => {
         interimTranscript = ''
         finalTranscript = ''
         this.disconnect('RESET')
         this.setState({ interimTranscript, finalTranscript })
       }
 
-      @autobind
-      startListening() {
+      startListening = () => {
         if (recognition && !listening) {
           try {
             recognition.start()
@@ -118,15 +114,13 @@ export default function SpeechRecognition(options) {
         }
       }
 
-      @autobind
-      abortListening() {
+      abortListening = () => {
         listening = false
         this.setState({ listening })
         this.disconnect('ABORT')
       }
 
-      @autobind
-      stopListening() {
+      stopListening = () => {
         listening = false
         this.setState({ listening })
         this.disconnect('STOP')


### PR DESCRIPTION
- Stop depending on `core-decorators`.
- If rendered on the server, don't fail when trying to access `window`.