### PR TITLE
New option to disable continuous listening

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ Sets the transcription to an empty string.
 
 Causes the Web Speech API to start listening to speech from the microphone.
 
+*NOTE: if `continuous` option is set to `false`, then it will reset the `transcript` prop after the next invoke of `startListening` 
+[here](https://github.com/FoundersFactory/react-speech-recognition#continuous-bool)
+
 ### stopListening [function]
 
 Causes the Web Speech API to stop listening to speech from the microphone, but will finish processing any remaining speech.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ or in ES7:
 
 By default, the Speech Recognition API is listening to speech from the microphone. To have the API turned off by default, set this to `false`.
 
+### continuous [bool]
+
+By default, the Speech Recognition API is continously listening to speech from the microphone. To have the API turned off after the user has finished speaking, or the input is no longer there, set this to `false`.
+
 ## Props added to your component
 
 ### transcript [string]

--- a/README.md
+++ b/README.md
@@ -91,7 +91,14 @@ By default, the Speech Recognition API is listening to speech from the microphon
 
 ### continuous [bool]
 
-By default, the Speech Recognition API is continously listening to speech from the microphone. To have the API turned off after the user has finished speaking, or the input is no longer there, set this to `false`.
+By default, the Speech Recognition API is continously listening to speech from the microphone. To have the API turned off after the user has finished speaking, or the input is no longer there, set this to `false`. For example, if you had a chat app that should start listening to user's speech/input after clicking a button, you should set `continuous` to `false` like this:
+```
+const options = {
+  autoStart: false,
+  continuous: false 
+}
+export default SpeechRecognition(options)(YourComponent)
+```
 
 ## Props added to your component
 

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -40,7 +40,7 @@ export default function SpeechRecognition(options) {
 
       componentWillMount() {
         if (recognition) {
-          recognition.continuous = options.continuous || true
+          recognition.continuous = recognition.continuous = options.continuous ? true : false
           recognition.interimResults = true
           recognition.onresult = this.updateTranscript.bind(this)
           recognition.onend = this.onRecognitionDisconnect.bind(this)

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -71,7 +71,7 @@ export default function SpeechRecognition(options) {
         listening = false
         if (pauseAfterDisconnect) {
           this.setState({ listening })
-        } else if (typeof options.continuous === 'undefined') {
+        } else if (recognition && recognition.continuous) {
           this.startListening()
         }
         pauseAfterDisconnect = false

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -108,6 +108,9 @@ export default function SpeechRecognition(options) {
 
       startListening = () => {
         if (recognition && !listening) {
+          if (!recognition.continuous) {
+            this.resetTranscript()
+          }
           try {
             recognition.start()
           } catch (DOMException) {

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -40,7 +40,7 @@ export default function SpeechRecognition(options) {
 
       componentWillMount() {
         if (recognition) {
-          recognition.continuous = recognition.continuous = options.continuous ? true : false
+          recognition.continuous = recognition.continuous = !options.continuous ? false : true
           recognition.interimResults = true
           recognition.onresult = this.updateTranscript.bind(this)
           recognition.onend = this.onRecognitionDisconnect.bind(this)

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -40,7 +40,7 @@ export default function SpeechRecognition(options) {
 
       componentWillMount() {
         if (recognition) {
-          recognition.continuous = recognition.continuous = !options.continuous ? false : true
+          recognition.continuous = options.continuous !== false
           recognition.interimResults = true
           recognition.onresult = this.updateTranscript.bind(this)
           recognition.onend = this.onRecognitionDisconnect.bind(this)

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -72,9 +72,9 @@ export default function SpeechRecognition(options) {
         if (pauseAfterDisconnect) {
           this.setState({ listening })
         } else if (recognition) {
-          if(recognition.continuous) {
+          if (recognition.continuous) {
             this.startListening()
-          }else{
+          } else {
             this.setState({ listening })
           }
         }

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -71,8 +71,12 @@ export default function SpeechRecognition(options) {
         listening = false
         if (pauseAfterDisconnect) {
           this.setState({ listening })
-        } else if (recognition && recognition.continuous) {
-          this.startListening()
+        } else if (recognition) {
+          if(recognition.continuous) {
+            this.startListening()
+          }else{
+            this.setState({ listening })
+          }
         }
         pauseAfterDisconnect = false
       }

--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -40,7 +40,7 @@ export default function SpeechRecognition(options) {
 
       componentWillMount() {
         if (recognition) {
-          recognition.continuous = true
+          recognition.continuous = options.continuous || true
           recognition.interimResults = true
           recognition.onresult = this.updateTranscript.bind(this)
           recognition.onend = this.onRecognitionDisconnect.bind(this)
@@ -71,7 +71,7 @@ export default function SpeechRecognition(options) {
         listening = false
         if (pauseAfterDisconnect) {
           this.setState({ listening })
-        } else {
+        } else if (typeof options.continuous === 'undefined') {
           this.startListening()
         }
         pauseAfterDisconnect = false


### PR DESCRIPTION
I've added the new option to enable users to control the API. Using a new option property, users can enable/disable the continuous listening of the API. I kept the default configs to be continuous and made the necessary modifications that will add the feature. 