### PR TITLE
fix: graceful exit in safari

### DIFF
--- a/src/SpeechRecognition.js
+++ b/src/SpeechRecognition.js
@@ -31,10 +31,12 @@ export default function SpeechRecognition(options) {
       constructor(props) {
         super(props)
 
-        recognition.continuous = options.continuous !== false
-        recognition.interimResults = true
-        recognition.onresult = this.updateTranscript.bind(this)
-        recognition.onend = this.onRecognitionDisconnect.bind(this)
+        if (browserSupportsSpeechRecognition  && recognition != null) {
+          recognition.continuous = options.continuous !== false
+          recognition.interimResults = true
+          recognition.onresult = this.updateTranscript.bind(this)
+          recognition.onend = this.onRecognitionDisconnect.bind(this)
+        }
 
         this.state = {
           interimTranscript,


### PR DESCRIPTION
it tries to set values on a null recognition reference in lines 31 onwards (constructor)
added a check to ensure it's not null