### PR TITLE
Collect final transcripts correctly in Android

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,16 @@
+const debounce = (func, wait, immediate) => {
+  let timeout
+  return function() {
+    const context = this, args = arguments // eslint-disable-line no-undef
+    const later = function() {
+      timeout = null
+      if (!immediate) func.apply(context, args)
+    }
+    const callNow = immediate && !timeout
+    clearTimeout(timeout)
+    timeout = setTimeout(later, wait)
+    if (callNow) func.apply(context, args)
+  }
+}
+
+export { debounce }


### PR DESCRIPTION
On Android, there are two strange behaviours as documented [here](https://stackoverflow.com/questions/35112561/speech-recognition-api-duplicated-phrases-on-android/43458449#43458449):
- Interim transcripts are marked as "final" with confidence 0
- Final transcripts are often emitted twice

This PR handles this by doing the following:
- Treating "final" transcripts with confidence 0 as interim transcripts on Android
- Debouncing final transcripts on Android, waiting 250ms between each one